### PR TITLE
Add Gradle with JUnit tests for InventoryManager

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,28 @@
+plugins {
+    id 'java'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
+}
+
+test {
+    useJUnitPlatform()
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs = ['grocerystore', 'inventorymanager', 'testinventory', 'src/main/java']
+        }
+    }
+    test {
+        java {
+            srcDirs = ['src/test/java']
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'InventoryManagementApplication'

--- a/src/main/java/inventoryexception/InventoryException.java
+++ b/src/main/java/inventoryexception/InventoryException.java
@@ -1,0 +1,7 @@
+package inventoryexception;
+
+public class InventoryException extends Exception {
+    public InventoryException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/inventorymanager/InventoryManagerTest.java
+++ b/src/test/java/inventorymanager/InventoryManagerTest.java
@@ -1,0 +1,31 @@
+package inventorymanager;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+public class InventoryManagerTest {
+    @Test
+    public void testFindItemIndex() {
+        String[][] inventory = {
+            {"Apple", "10"},
+            {"Banana", "5"},
+            {"Carrot", "20"}
+        };
+
+        int index = InventoryManager.findItemIndex(inventory, "Banana");
+        assertEquals(1, index, "Expected index of Banana to be 1");
+    }
+
+    @Test
+    public void testUpdateInventory() {
+        String[][] inventory = {
+            {"Apple", "10"},
+            {"Banana", "5"},
+            {"Carrot", "20"}
+        };
+
+        InventoryManager.updateInventory(inventory, 1, 15);
+        assertEquals("15", inventory[1][1], "Quantity should be updated to 15");
+    }
+}


### PR DESCRIPTION
## Summary
- add Gradle build files configured for JUnit 5
- create an `InventoryException` used by existing classes
- add JUnit tests for `InventoryManager`

## Testing
- `gradle test --no-daemon` *(fails: Could not resolve org.junit.jupiter due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68427298fb84832d87d024319c966691